### PR TITLE
Fix: Improve chat endpoint streaming and error handling

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -44,6 +44,7 @@ class Message(Base):
     created_at = Column(DateTime, default=datetime.utcnow)
     parent_message_id = Column(UUID(as_uuid=True), nullable=True)
     branch_id = Column(UUID(as_uuid=True), nullable=True)
+    error_info = Column(Text, nullable=True) # New field
 
 class SharedLink(Base):
     __tablename__ = "shared_links"


### PR DESCRIPTION
This commit addresses issues in the /chat endpoint related to streaming and database saving:

1.  Refactored message saving for assistant responses to occur in a `finally` block. This ensures that an attempt to save the message is made even if errors occur during stream generation from the AI provider.
2.  Introduced an `error_info` field to the `Message` model (TEXT, nullable). This field stores error details if a message could not be fully generated.
3.  Updated the /chat endpoint to populate `error_info` when an error occurs during `litellm.completion`. It saves partial content if available, or a generic error message in `content`.
4.  Modified the streaming response to send a JSON error object (`{"error": "..."}`) to you if a generation error occurs. The `{"done": true}` message is suppressed in such cases.
5.  Updated `MessageResponse` Pydantic model to include `error_info`.
6.  Modified `get_thread_messages` and `get_shared_thread` endpoints to include `error_info` in their responses, allowing the frontend to display information about messages that were not completed successfully.

These changes make the chat endpoint more robust in handling errors during streaming and ensure that the state of messages (complete, partial, or errored) is better represented both in the database and in API responses to you. This should help resolve rendering issues and provide clearer error feedback.