### PR TITLE
feat: Enhance markdown rendering and chat UI

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -37,6 +37,7 @@
         "@radix-ui/react-toggle-group": "^1.1.0",
         "@radix-ui/react-tooltip": "^1.1.4",
         "@tanstack/react-query": "^5.56.2",
+        "@types/react-syntax-highlighter": "^15.5.13",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0",
@@ -3060,6 +3061,15 @@
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router": "*"
+      }
+    },
+    "node_modules/@types/react-syntax-highlighter": {
+      "version": "15.5.13",
+      "resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-15.5.13.tgz",
+      "integrity": "sha512-uLGJ87j6Sz8UaBAooU0T6lWJ0dBmjZgN1PZTrj05TNql2/XpC6+4HhMT5syIdFUUt+FASfCeLLv4kBygNU+8qA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/unist": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,6 +40,7 @@
     "@radix-ui/react-toggle-group": "^1.1.0",
     "@radix-ui/react-tooltip": "^1.1.4",
     "@tanstack/react-query": "^5.56.2",
+    "@types/react-syntax-highlighter": "^15.5.13",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",

--- a/frontend/src/components/chat/ChatMessage.tsx
+++ b/frontend/src/components/chat/ChatMessage.tsx
@@ -1,5 +1,9 @@
 
 import React from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import { oneDark } from "react-syntax-highlighter/dist/esm/styles/prism";
 import { cn } from "@/lib/utils";
 import { format } from "date-fns";
 
@@ -57,7 +61,32 @@ export const ChatMessage: React.FC<ChatMessageProps> = ({ role, content, timesta
           </div>
         );
       default:
-        return <p>{content}</p>;
+        return (
+          <ReactMarkdown
+            remarkPlugins={[remarkGfm]}
+            components={{
+              code({ node, inline, className, children, ...props }) {
+                const match = /language-(\w+)/.exec(className || "");
+                return !inline && match ? (
+                  <SyntaxHighlighter
+                    style={oneDark}
+                    language={match[1]}
+                    PreTag="div"
+                    {...props}
+                  >
+                    {String(children).replace(/\n$/, "")}
+                  </SyntaxHighlighter>
+                ) : (
+                  <code className={className} {...props}>
+                    {children}
+                  </code>
+                );
+              },
+            }}
+          >
+            {content}
+          </ReactMarkdown>
+        );
     }
   };
 
@@ -76,7 +105,7 @@ export const ChatMessage: React.FC<ChatMessageProps> = ({ role, content, timesta
             ? "bg-blue-600 text-white"
             : isSystem
             ? "bg-slate-700 text-white"
-            : "bg-slate-600 text-white"
+            : "bg-gray-700 text-white"
         )}
       >
         {renderContent()}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -102,3 +102,46 @@
     @apply bg-background text-foreground;
   }
 }
+
+/* Markdown Global Styles */
+
+/* Code blocks */
+pre > div {
+  padding: 1rem;
+  border-radius: 0.5rem; /* Tailwind's `rounded-lg` */
+  overflow-x: auto;
+  font-family: 'monospace'; /* Ensure a monospace font */
+  font-size: 0.875rem; /* Tailwind's `text-sm` */
+}
+
+/* Inline code */
+code:not(pre > code) {
+  background-color: #374151; /* Tailwind's `bg-gray-700` */
+  color: #e5e7eb; /* Tailwind's `text-gray-200` */
+  padding: 0.2rem 0.4rem;
+  border-radius: 0.25rem; /* Tailwind's `rounded-sm` */
+  font-size: 0.85em; /* Slightly smaller than surrounding text */
+  font-family: 'monospace';
+}
+
+/* Blockquotes */
+blockquote {
+  border-left: 4px solid #4b5563; /* Tailwind's `border-gray-600` */
+  padding-left: 1rem;
+  margin-left: 0;
+  font-style: italic;
+  color: #d1d5db; /* Tailwind's `text-gray-300` */
+}
+
+/* Lists */
+ul, ol {
+  margin-left: 1.5rem;
+  list-style-position: outside;
+}
+
+/* Headings */
+h1, h2, h3, h4, h5, h6 {
+  font-weight: 600; /* Tailwind's `font-semibold` */
+  margin-top: 1em;
+  margin-bottom: 0.5em;
+}


### PR DESCRIPTION
- Integrate `react-markdown` and `remark-gfm` for markdown parsing in chat messages.
- Add code block syntax highlighting using `react-syntax-highlighter` with the `oneDark` theme.
- Style various markdown elements (code blocks, inline code, blockquotes, lists, headings) for a more professional and cohesive look.
- Refine chat message styling by adjusting the assistant message background color for better visual differentiation.

These changes improve the readability and presentation of messages, especially those containing code, and provide a more polished user experience in the chat interface.